### PR TITLE
Fix type hint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "riweather"
-version = "0.5.0"
+version = "0.5.1"
 description = "Grab publicly available weather data"
 authors = ["John Ensley <jensley@resource-innovations.com>"]
 license = "Apache-2.0"

--- a/src/riweather/stations.py
+++ b/src/riweather/stations.py
@@ -399,7 +399,7 @@ class Station:  # noqa: D101
     def fetch_temp_data(
         self,
         year: int = None,
-        value: int = None,
+        value: str = None,
         scale: str = "C",
         period: str = "H",
         rollup: str = "ending",


### PR DESCRIPTION
The argument to `fetch_temp_data` that controls which value gets returned (temperature or dew point) had a type hint of `int` for some reason. That was getting flagged by IDEs any time `riweather` is used in other projects. This changes it to `str` and should solve that problem.